### PR TITLE
fix配列表現を消去

### DIFF
--- a/data.json
+++ b/data.json
@@ -7,10 +7,10 @@
     "class2": {
       "description": "Writing Assignment 1",
       "deadline": { "year": 23, "month": 10, "day": 14, "hour": 23 }
-    },
-    "情報連携学概論": {
-      "description": "4-1",
-      "deadline": { "year": 23, "month": 10, "day": 14, "hour": 23 }
     }
+  },
+  "情報連携学概論": {
+    "description": "4-1",
+    "deadline": { "year": 23, "month": 10, "day": 14, "hour": 23 }
   }
 }


### PR DESCRIPTION
 ```cs2: {
    description: "3-e-1",
    deadline: [{ year: 23, month: 10, day: 14, hour: 23 }]
  }　
```

みたいな感じでdeadlineは配列にした方が何となくきれいな気がするけどそれだとうまくいかなかった、ごめん

```cs2: {
    description: "3-e-1",
    deadline: { year: 23, month: 10, day: 14, hour: 23 }
  }
```
これだと ``` hoge.cs2.description ```,``` hoge.cs2.deadline.year```って指定できる

